### PR TITLE
Update users table migration for two-factor fields

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -16,9 +16,9 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->text('two_factor_secret')->after('password')->nullable();
-            $table->text('two_factor_recovery_codes')->after('two_factor_secret')->nullable();
-            $table->timestamp('two_factor_confirmed_at')->after('two_factor_recovery_codes')->nullable();
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });


### PR DESCRIPTION
This pull request makes a small adjustment to the migration for the `users` table. The change removes the use of the `after` clause when adding two-factor authentication related columns, which simplifies the migration and avoids potential issues with column ordering.

* Removed the `after` clause from the definitions of `two_factor_secret`, `two_factor_recovery_codes`, and `two_factor_confirmed_at` columns in the `users` table migration, so these columns are now simply appended in the default order.