### PR TITLE
Add /tmp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+/tmp/


### PR DESCRIPTION
PHPStan uses /tmp/ which can add 50+ files that it tracks, we do not need these tracked by git at all.