### PR TITLE
Fix: Added missing Rate Limiter for 2FA route

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -33,5 +33,6 @@ final class FortifyServiceProvider extends ServiceProvider
     private function bootRateLimitingDefaults(): void
     {
         RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by($request->string('email')->value().$request->ip()));
+        RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(5)->by($request->session()->get('login.id')));
     }
 }


### PR DESCRIPTION
Added the missing Rate Limiter for the 2FA route from the https://github.com/laravel/react-starter-kit

https://github.com/laravel/react-starter-kit/blob/main/app/Providers/FortifyServiceProvider.php