### PR TITLE
Removes `Hash` from password actions.

### DIFF
--- a/app/Actions/CreateUser.php
+++ b/app/Actions/CreateUser.php
@@ -6,7 +6,6 @@ namespace App\Actions;
 
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
-use Illuminate\Support\Facades\Hash;
 use SensitiveParameter;
 
 final readonly class CreateUser
@@ -18,7 +17,7 @@ final readonly class CreateUser
     {
         $user = User::query()->create([
             ...$attributes,
-            'password' => Hash::make($password),
+            'password' => $password,
         ]);
 
         event(new Registered($user));

--- a/app/Actions/CreateUserPassword.php
+++ b/app/Actions/CreateUserPassword.php
@@ -6,7 +6,6 @@ namespace App\Actions;
 
 use App\Models\User;
 use Illuminate\Auth\Events\PasswordReset;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
 use SensitiveParameter;
@@ -22,7 +21,7 @@ final readonly class CreateUserPassword
             $credentials,
             function (User $user) use ($password): void {
                 $user->update([
-                    'password' => Hash::make($password),
+                    'password' => $password,
                     'remember_token' => Str::random(60),
                 ]);
 

--- a/app/Actions/UpdateUserPassword.php
+++ b/app/Actions/UpdateUserPassword.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Models\User;
-use Illuminate\Support\Facades\Hash;
 use SensitiveParameter;
 
 final readonly class UpdateUserPassword
@@ -13,7 +12,7 @@ final readonly class UpdateUserPassword
     public function handle(User $user, #[SensitiveParameter] string $password): void
     {
         $user->update([
-            'password' => Hash::make($password),
+            'password' => $password,
         ]);
     }
 }


### PR DESCRIPTION
The password attribute in the User model is already being cast as  `'password' => 'hashed'`. Therefore, the `Hash::make` is no longer necessary. 👍