### PR TITLE
Mention the need for a coverage driver in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This isn't just another Laravel boilerplate—it's a statement that PHP applicat
 
 ## Getting Started
 
-> **Requires [PHP 8.4+](https://php.net/releases/)**.
+> **Requires [PHP 8.4+](https://php.net/releases/) and a code coverage driver like [xdebug](https://xdebug.org/docs/install)**.
 
 Create your type-safe Laravel application using [Composer](https://getcomposer.org):
 


### PR DESCRIPTION
I am not sure what driver you would prefer to recommend. I am also not sure if the repo should have a simple link to the driver or a brief guide including recommending keeping xdebug off and only enabling for `test:unit` by prefixing with `@putenv XDEBUG_MODE=coverage`.

The MVP is mentioning that it is a requirement to have something, because I was presented with an error when trying to follow the instructions from the README.