### PR TITLE
docs: fix the readme link to use Nuno's Vue kit not grnspc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 - Inertia & React (this project) version: **[github.com/nunomaduro/laravel-starter-kit-inertia-react](https://github.com/nunomaduro/laravel-starter-kit-inertia-react)**
 - Blade version: **[github.com/nunomaduro/laravel-starter-kit](https://github.com/nunomaduro/laravel-starter-kit)**
-- Inertia & Vue version: **[github.com/grnspc/laravel-starter-kit-inertia-vue](https://github.com/grnspc/laravel-starter-kit-inertia-vue)**
+- Inertia & Vue version: **[github.com/nunomaduro/laravel-starter-kit-inertia-vue](https://github.com/nunomaduro/laravel-starter-kit-inertia-vue)**
 
 <p align="center">
     <a href="https://youtu.be/VhzP0XWGTC4" target="_blank">


### PR DESCRIPTION
Fixes #23 

A rouge pr was approved and merged by another user who set the README to their own Vue kit this PR fix's the README to point to the correct kit.