### PR TITLE
build(deps): remove redundant rector/rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,15 @@
         "larastan/larastan": "^3.10.0",
         "laravel/boost": "^2.4.11",
         "laravel/pail": "^1.2.7",
+        "laravel/pao": "^1.1.2",
         "laravel/pint": "^1.29.3",
         "laravel/tinker": "^3.0.2",
         "mockery/mockery": "^1.6.12",
         "nunomaduro/collision": "^8.9.4",
-        "laravel/pao": "^1.1.2",
         "pestphp/pest": "^5.0",
         "pestphp/pest-plugin-browser": "^5.0",
         "pestphp/pest-plugin-laravel": "^5.0",
         "pestphp/pest-plugin-type-coverage": "^5.0",
-        "rector/rector": "^2.5.2",
         "roave/security-advisories": "dev-latest"
     },
     "autoload": {


### PR DESCRIPTION
Removes `rector/rector` since it is already brought in as a nested dependency of `driftingly/rector-laravel`, making it redundant.

Also, reordered `laravel/pao` to maintain alphabetical order within `composer.json`.