### PR TITLE
Fix reset password form to use the correct route

### DIFF
--- a/resources/js/pages/user-password/create.tsx
+++ b/resources/js/pages/user-password/create.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import AuthLayout from '@/layouts/auth-layout';
-import { update } from '@/routes/password';
+import { store } from '@/routes/password';
 
 type Props = {
     token: string;
@@ -22,7 +22,7 @@ export default function ResetPassword({ token, email }: Props) {
             <Head title="Reset password" />
 
             <Form
-                {...update.form()}
+                {...store.form()}
                 transform={(data) => ({ ...data, token, email })}
                 resetOnSuccess={['password', 'password_confirmation']}
             >


### PR DESCRIPTION
The reset password page currently uses update.form(), which resolves to the authenticated password update route (PUT /settings/password).

Since this page is used by the password reset flow (via the reset email link), it should submit to the password reset endpoint (POST /reset-password), which is handled by UserPasswordController::store() and accepts the reset token and email.

This PR updates the form to use store.form() instead of update.form().