### PR TITLE
chore(rector): make cache dir project-relative

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -29,7 +29,7 @@ return RectorConfig::configure()
     )
     ->withComposerBased(laravel: true)
     ->withCache(
-        cacheDirectory: '/tmp/rector',
+        cacheDirectory: __DIR__.'/tmp/rector',
         cacheClass: FileCacheStorage::class,
     )
     ->withPaths([


### PR DESCRIPTION
Not sure if omitting `__DIR__` here was intentional, so I added it.

Previously, this would create the `tmp` folder in root of disk partition (at least on Windows). This change should also match PHPStan's tmp directory inside the project.